### PR TITLE
Removing obsolete SFP (99) records.

### DIFF
--- a/ansible/roles/sfmix_dns/templates/zones/na-ix.net.j2
+++ b/ansible/roles/sfmix_dns/templates/zones/na-ix.net.j2
@@ -19,7 +19,6 @@ $TTL 3600
 @               IN      A       192.33.255.3
 @               IN      MX      5       mail
 @               IN      TXT     "v=spf1 mx ~all"
-@               IN      SPF     "v=spf1 mx ~all"
 
 www             IN      A       192.33.255.3
 mail            IN      A       192.33.255.3

--- a/ansible/roles/sfmix_dns/templates/zones/na-ix.org.j2
+++ b/ansible/roles/sfmix_dns/templates/zones/na-ix.org.j2
@@ -19,7 +19,6 @@ $TTL 3600
 @               IN      A       192.33.255.3
 @               IN      MX      5       mail
 @               IN      TXT     "v=spf1 mx ~all"
-@               IN      SPF     "v=spf1 mx ~all"
 
 lists           IN      A       67.221.240.200
 lists		IN	AAAA	2607:fae0:1::200

--- a/ansible/roles/sfmix_dns/templates/zones/sfmix.org.j2
+++ b/ansible/roles/sfmix_dns/templates/zones/sfmix.org.j2
@@ -24,7 +24,6 @@ $TTL 3600
 @			IN	MX	10 ALT3.ASPMX.L.GOOGLE.COM.
 @			IN	MX	10 ALT4.ASPMX.L.GOOGLE.COM.
 @			IN	TXT	"v=spf1 include:_spf.google.com ~all"
-@			IN	SPF	"v=spf1 include:_spf.google.com ~all"
 mail			IN	CNAME	ghs.googlehosted.com.
 _dmarc			IN	TXT	"v=DMARC1; p=none; sp=none; rf=afrf; pct=100; ri=86400"
 googlea994b6d001486007	IN	CNAME	google.com.


### PR DESCRIPTION
SPF (99) records were deprecated in 2014.  They are to be embedded in a TXT record now.