### PR TITLE
feat(portal): make /participants/ the home page with my-networks buttons

### DIFF
--- a/portal/dashboard/views.py
+++ b/portal/dashboard/views.py
@@ -57,21 +57,7 @@ def logout_view(request):
 
 @login_required
 def index(request):
-    asns = request.session.get("oidc_asns", [])
-    participants = []
-    if asns:
-        try:
-            lg = get_lg_client()
-            all_participants = lg.get_participants()
-            asn_set = set(asns)
-            participants = [p for p in all_participants if p.get("asn") in asn_set]
-        except Exception:
-            pass
-    return render(request, "dashboard/index.html", {
-        "asns": asns,
-        "participants": participants,
-        "is_ix_admin": _is_ix_admin(request),
-    })
+    return redirect("participants_list")
 
 
 @login_required
@@ -312,14 +298,20 @@ def participants_list(request):
     """Public IXP participant list (no auth required)."""
     entries = []
     lg_error = None
+    my_participants = []
     try:
         lg = LookingGlassClient()
         if lg.base_url:
-            entries = sorted(lg.get_participants(), key=lambda p: p.get("asn", 0))
+            all_participants = lg.get_participants()
+            entries = sorted(all_participants, key=lambda p: p.get("asn", 0))
+            if request.user.is_authenticated:
+                user_asns = set(request.session.get("oidc_asns", []))
+                my_participants = [p for p in all_participants if p.get("asn") in user_asns]
     except Exception as e:
         lg_error = str(e)
     return render(request, "dashboard/participants_list.html", {
         "entries": entries,
+        "my_participants": my_participants,
         "lg_error": lg_error,
         "is_ix_admin": _is_ix_admin(request) if request.user.is_authenticated else False,
     })

--- a/portal/templates/dashboard/participants_list.html
+++ b/portal/templates/dashboard/participants_list.html
@@ -4,6 +4,21 @@
 {% block content %}
 <h1 class="text-2xl font-bold mb-6">IXP Participants</h1>
 
+{% if my_participants %}
+<div class="mb-6">
+  <p class="text-sm text-gray-500 mb-2">Your Networks</p>
+  <div class="flex flex-wrap gap-2">
+    {% for member in my_participants %}
+    <a href="{% url 'participant_detail' member.asn %}"
+       class="inline-flex items-center gap-2 bg-indigo-50 border border-indigo-200 rounded-lg px-4 py-2 hover:bg-indigo-100 hover:border-indigo-400 transition group">
+      <span class="font-mono text-xs font-semibold text-indigo-700">AS{{ member.asn }}</span>
+      <span class="text-sm text-gray-700 group-hover:text-indigo-800">{{ member.name }}</span>
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% endif %}
+
 {% if lg_error %}
 <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-sm text-yellow-800 mb-6">
   Unable to fetch participant list: {{ lg_error }}


### PR DESCRIPTION
## Summary

- `GET /` now redirects to `/participants/` (after login) instead of rendering a separate dashboard
- `/participants/` fetches the authenticated user's own networks and displays them as indigo pill-buttons above the full participant table
- Non-authenticated users see the full table with no buttons (behavior unchanged)
- The old `dashboard/index.html` template is no longer rendered (index view is now a one-liner redirect)

## Test plan

- [ ] Log in — confirm you land at `/participants/`
- [ ] Confirm your ASN(s) appear as buttons above the table
- [ ] Click a button — confirm it goes to the participant detail page
- [ ] Log out — confirm `/participants/` still shows the full table with no "Your Networks" section