### PR TITLE
Cap MACs-per-IP + restore route-server OOM/memory limits

### DIFF
--- a/ansible/roles/sfmix_route_server_linux/tasks/lg-neighborhood-watch.yml
+++ b/ansible/roles/sfmix_route_server_linux/tasks/lg-neighborhood-watch.yml
@@ -91,6 +91,11 @@
       PrivateTmp=true
       ReadOnlyPaths=/etc/lg-neighborhood-watch
 
+      # Bound memory and make this the first OOM victim, so bird (critical) is
+      # never the one killed under host memory pressure.
+      MemoryMax=128M
+      OOMScoreAdjust=1000
+
       [Install]
       WantedBy=multi-user.target
     dest: /etc/systemd/system/lg-neighborhood-watch.service

--- a/looking-glass/lg-neighborhood-watch/src/store.rs
+++ b/looking-glass/lg-neighborhood-watch/src/store.rs
@@ -10,9 +10,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde::Serialize;
 use tokio::sync::mpsc;
+
+/// Maximum distinct MACs retained per IP, bounding memory against an attacker
+/// flooding spoofed MACs on the segment. Keeps the most-recently-heard, evicts
+/// the oldest. (lg-server applies the same cap downstream.)
+const MAX_MACS_PER_IP: usize = 8;
 
 /// One frame parsed off the wire: a MAC heard claiming an IP.
 #[derive(Debug, Clone)]
@@ -84,6 +89,7 @@ pub async fn run_writer(mut rx: mpsc::Receiver<Observation>, table: Arc<ArcSwap<
                         iface: obs.iface,
                         count: 1,
                     });
+                cap_macs(macs);
                 dirty = true;
             }
             _ = tick.tick() => {
@@ -93,6 +99,30 @@ pub async fn run_writer(mut rx: mpsc::Receiver<Observation>, table: Arc<ArcSwap<
                 }
             }
         }
+    }
+}
+
+/// Evict oldest-by-last_heard MACs until the per-IP cap is satisfied.
+fn cap_macs(macs: &mut HashMap<String, Entry>) {
+    while macs.len() > MAX_MACS_PER_IP {
+        let oldest = macs
+            .iter()
+            .min_by(|a, b| ts_cmp(&a.1.last_heard, &b.1.last_heard))
+            .map(|(k, _)| k.clone());
+        match oldest {
+            Some(k) => {
+                macs.remove(&k);
+            }
+            None => break,
+        }
+    }
+}
+
+/// Order two RFC3339 timestamps (lexical fallback for unparseable input).
+fn ts_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+    match (DateTime::parse_from_rfc3339(a), DateTime::parse_from_rfc3339(b)) {
+        (Ok(ta), Ok(tb)) => ta.cmp(&tb),
+        _ => a.cmp(b),
     }
 }
 

--- a/looking-glass/lg-neighborhood-watch/src/store.rs
+++ b/looking-glass/lg-neighborhood-watch/src/store.rs
@@ -14,10 +14,11 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 use tokio::sync::mpsc;
 
-/// Maximum distinct MACs retained per IP, bounding memory against an attacker
-/// flooding spoofed MACs on the segment. Keeps the most-recently-heard, evicts
-/// the oldest. (lg-server applies the same cap downstream.)
-const MAX_MACS_PER_IP: usize = 8;
+/// Maximum distinct MACs retained per IP, bounding per-IP memory against an
+/// attacker flooding spoofed MACs on the segment. Keeps the most-recently-heard,
+/// evicts the oldest. (lg-server applies the same cap downstream. The sensor's
+/// total-IP dimension is bounded by the unit's MemoryMax, not this.)
+const MAX_MACS_PER_IP: usize = 100;
 
 /// One frame parsed off the wire: a MAC heard claiming an IP.
 #[derive(Debug, Clone)]

--- a/looking-glass/src/discovered.rs
+++ b/looking-glass/src/discovered.rs
@@ -22,6 +22,13 @@ use tracing::{info, warn};
 
 use crate::structured::{DiscoveredMac, DiscoveredNeighbor};
 
+/// Maximum distinct MACs retained per IP. A legitimate IP has one (a real
+/// conflict two or three); the cap bounds memory and response size against an
+/// attacker flooding spoofed MACs for an assigned IP. The conflict flag still
+/// fires (it only needs >1), so the spoofing signal is preserved; we keep the
+/// most-recently-heard MACs and evict the oldest.
+const MAX_MACS_PER_IP: usize = 8;
+
 /// One row as reported by the sensor's `GET /neighbors`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct SensorObservation {
@@ -181,6 +188,7 @@ impl DiscoveredNeighborStore {
                     t.last_seen = max_ts(&t.last_seen, &last);
                 })
                 .or_insert(MacTimes { first_seen: first, last_seen: last });
+            cap_macs(&mut rec.macs);
         }
 
         self.fetched_at = Some(now_str);
@@ -325,6 +333,30 @@ pub async fn fetch_sensor(base_url: &str) -> Result<Vec<SensorObservation>> {
     Ok(observations)
 }
 
+/// Evict oldest-by-last_seen MACs until the per-IP cap is satisfied.
+fn cap_macs(macs: &mut HashMap<String, MacTimes>) {
+    while macs.len() > MAX_MACS_PER_IP {
+        let oldest = macs
+            .iter()
+            .min_by(|a, b| ts_cmp(&a.1.last_seen, &b.1.last_seen))
+            .map(|(k, _)| k.clone());
+        match oldest {
+            Some(k) => {
+                macs.remove(&k);
+            }
+            None => break,
+        }
+    }
+}
+
+/// Order two RFC3339 timestamps (lexical fallback for unparseable input).
+fn ts_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+    match (DateTime::parse_from_rfc3339(a), DateTime::parse_from_rfc3339(b)) {
+        (Ok(ta), Ok(tb)) => ta.cmp(&tb),
+        _ => a.cmp(b),
+    }
+}
+
 /// Compare two RFC3339 timestamps, returning the earlier (string preserved).
 fn min_ts(a: &str, b: &str) -> String {
     match (DateTime::parse_from_rfc3339(a), DateTime::parse_from_rfc3339(b)) {
@@ -449,6 +481,29 @@ mod tests {
         // Next poll: IP no longer assigned.
         store.update_at(&[], &[], at("2026-06-18T00:05:00Z"));
         assert!(store.snapshot().neighbors.is_empty());
+    }
+
+    #[test]
+    fn macs_per_ip_are_capped_keeping_newest() {
+        let mut store = DiscoveredNeighborStore::load(None);
+        // Flood many MACs for one assigned IP, each newer than the last.
+        let obs: Vec<SensorObservation> = (0..20)
+            .map(|i| obs(
+                "10.0.0.1",
+                &format!("aa:00:00:00:00:{:02x}", i),
+                &format!("2026-06-18T00:{:02}:00Z", i),
+                &format!("2026-06-18T00:{:02}:00Z", i),
+            ))
+            .collect();
+        store.update_at(&obs, &[assign("10.0.0.1", 64500, "Acme")], at("2026-06-18T01:00:00Z"));
+        let snap = store.snapshot();
+        let n = neighbor(&snap, "10.0.0.1");
+        assert_eq!(n.macs.len(), MAX_MACS_PER_IP, "must cap MACs per IP");
+        assert!(n.conflict, "conflict signal preserved despite cap");
+        // The newest MAC (sequence 19) must survive; the oldest (00) must be evicted.
+        let kept: Vec<&str> = n.macs.iter().map(|m| m.mac.as_str()).collect();
+        assert!(kept.contains(&"aa:00:00:00:00:13"), "newest kept");
+        assert!(!kept.contains(&"aa:00:00:00:00:00"), "oldest evicted");
     }
 
     #[tokio::test]

--- a/looking-glass/src/discovered.rs
+++ b/looking-glass/src/discovered.rs
@@ -23,11 +23,12 @@ use tracing::{info, warn};
 use crate::structured::{DiscoveredMac, DiscoveredNeighbor};
 
 /// Maximum distinct MACs retained per IP. A legitimate IP has one (a real
-/// conflict two or three); the cap bounds memory and response size against an
-/// attacker flooding spoofed MACs for an assigned IP. The conflict flag still
-/// fires (it only needs >1), so the spoofing signal is preserved; we keep the
-/// most-recently-heard MACs and evict the oldest.
-const MAX_MACS_PER_IP: usize = 8;
+/// conflict a handful); this is generous headroom for flapping/history while
+/// still bounding memory and response size against an attacker flooding spoofed
+/// MACs for an assigned IP. The conflict flag still fires (it only needs >1), so
+/// the spoofing signal is preserved; we keep the most-recently-heard and evict
+/// the oldest. lg-server is bounded to assigned IPs, so worst case ~= 214 * this.
+const MAX_MACS_PER_IP: usize = 100;
 
 /// One row as reported by the sensor's `GET /neighbors`.
 #[derive(Debug, Clone, Deserialize)]
@@ -486,24 +487,26 @@ mod tests {
     #[test]
     fn macs_per_ip_are_capped_keeping_newest() {
         let mut store = DiscoveredNeighborStore::load(None);
-        // Flood many MACs for one assigned IP, each newer than the last.
-        let obs: Vec<SensorObservation> = (0..20)
+        // Flood more than the cap for one assigned IP, each newer than the last.
+        let n_flood = MAX_MACS_PER_IP + 12;
+        let mac = |i: usize| format!("aa:bb:cc:dd:{:02x}:{:02x}", (i >> 8) & 0xff, i & 0xff);
+        let obs: Vec<SensorObservation> = (0..n_flood)
             .map(|i| obs(
                 "10.0.0.1",
-                &format!("aa:00:00:00:00:{:02x}", i),
-                &format!("2026-06-18T00:{:02}:00Z", i),
-                &format!("2026-06-18T00:{:02}:00Z", i),
+                &mac(i),
+                &format!("2026-06-18T{:02}:{:02}:00Z", i / 60, i % 60),
+                &format!("2026-06-18T{:02}:{:02}:00Z", i / 60, i % 60),
             ))
             .collect();
-        store.update_at(&obs, &[assign("10.0.0.1", 64500, "Acme")], at("2026-06-18T01:00:00Z"));
+        store.update_at(&obs, &[assign("10.0.0.1", 64500, "Acme")], at("2026-06-18T05:00:00Z"));
         let snap = store.snapshot();
         let n = neighbor(&snap, "10.0.0.1");
         assert_eq!(n.macs.len(), MAX_MACS_PER_IP, "must cap MACs per IP");
         assert!(n.conflict, "conflict signal preserved despite cap");
-        // The newest MAC (sequence 19) must survive; the oldest (00) must be evicted.
+        // The newest MAC must survive; the oldest must be evicted.
         let kept: Vec<&str> = n.macs.iter().map(|m| m.mac.as_str()).collect();
-        assert!(kept.contains(&"aa:00:00:00:00:13"), "newest kept");
-        assert!(!kept.contains(&"aa:00:00:00:00:00"), "oldest evicted");
+        assert!(kept.contains(&mac(n_flood - 1).as_str()), "newest kept");
+        assert!(!kept.contains(&mac(0).as_str()), "oldest evicted");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Hardening follow-up to #7 (ARP/NDP discovery), from the post-merge security review.

## Changes
- **Cap MACs-per-IP at 8** in both layers (sensor `store.rs` + lg-server `discovered.rs`), evicting oldest-by-last-seen. Bounds memory/response size against spoofed-MAC floods for an assigned IP; the **conflict flag still fires** (needs only >1), so the spoofing signal is preserved.
- **Restore route-server protection** lost in the Docker→systemd rewrite: `MemoryMax=128M` + `OOMScoreAdjust=1000` on the sensor unit, so **bird** is never the OOM victim.

## Context (from the security review)
- lg-server already bounds the **IP dimension** — only NetBox-assigned IPs are tracked; unassigned IPs are dropped every poll, so they never reach the API/portal.
- The **sensor** hears *all* IPs on the segment by design (useful for spotting unassigned-IP squatting); `MemoryMax` is the backstop for that dimension.

## Tests
New `macs_per_ip_are_capped_keeping_newest` (cap enforced, newest kept, oldest evicted, conflict preserved); full discovered suite + clippy green.

## Not included (tracked separately)
Least-privilege of the sensor's RPC secret (grants `/rpc/v1/execute`) — design decision for a follow-up.